### PR TITLE
#16 - custom swing component

### DIFF
--- a/java/com/turbovnc/vncviewer/DesktopWindow.java
+++ b/java/com/turbovnc/vncviewer/DesktopWindow.java
@@ -84,7 +84,7 @@ class DesktopWindow extends JPanel implements Runnable, MouseListener,
     addKeyListener(this);
     addFocusListener(new FocusAdapter() {
       public void focusGained(FocusEvent e) {
-        if (cc.viewer.benchFile == null) checkClipboard();
+        if (cc.benchFile == null) checkClipboard();
       }
       public void focusLost(FocusEvent e) {
         cc.releaseModifiers();
@@ -250,7 +250,7 @@ class DesktopWindow extends JPanel implements Runnable, MouseListener,
         // optimal performance under X11 without requiring MIT-SHM pixmaps.
         if (!swingDB)
           RepaintManager.currentManager(this).setDoubleBufferingEnabled(false);
-        if (cc.viewer.benchFile != null)
+        if (cc.benchFile != null)
           paintImmediately(x, y, width, height);
         else
           repaint(x, y, width, height);
@@ -265,7 +265,7 @@ class DesktopWindow extends JPanel implements Runnable, MouseListener,
         }
         if (!swingDB)
           RepaintManager.currentManager(this).setDoubleBufferingEnabled(false);
-        if (cc.viewer.benchFile != null)
+        if (cc.benchFile != null)
           paintImmediately(x, y, r.width(), r.height());
         else
           repaint(x, y, r.width(), r.height());
@@ -543,7 +543,9 @@ class DesktopWindow extends JPanel implements Runnable, MouseListener,
           cc.losslessRefresh();
           return;
         case KeyEvent.VK_N:
-          VncViewer.newViewer(cc.viewer);
+        	if(cc.viewer instanceof VncViewer){
+        		VncViewer.newViewer((VncViewer)cc.viewer);
+        	}
           return;
         case KeyEvent.VK_O:
           cc.options.showDialog(cc.viewport);

--- a/java/com/turbovnc/vncviewer/DesktopWindow.java
+++ b/java/com/turbovnc/vncviewer/DesktopWindow.java
@@ -548,13 +548,13 @@ class DesktopWindow extends JPanel implements Runnable, MouseListener,
         	}
           return;
         case KeyEvent.VK_O:
-          cc.options.showDialog(cc.viewport);
+          cc.options.showDialog(cc.viewport.frame);
           return;
         case KeyEvent.VK_P:
           if (cc.profileDialog.isVisible())
             cc.profileDialog.endDialog();
           else
-            cc.profileDialog.showDialog(cc.viewport);
+            cc.profileDialog.showDialog(cc.viewport.frame);
           cc.toggleProfile();
           return;
         case KeyEvent.VK_R:

--- a/java/com/turbovnc/vncviewer/EmbeddedVncUsage.java
+++ b/java/com/turbovnc/vncviewer/EmbeddedVncUsage.java
@@ -1,0 +1,27 @@
+package com.turbovnc.vncviewer;
+
+import java.awt.BorderLayout;
+
+import javax.swing.JFrame;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingUtilities;
+
+public class EmbeddedVncUsage {
+
+  public static void main(String[] args) {
+    SwingUtilities.invokeLater(new Runnable() {
+
+      @Override
+      public void run() {
+        JFrame frame = new JFrame();
+        JPanel vncPanel = new JPanel();
+        new VncViewer(new String[] { "host:display", "toolbar=false" }, vncPanel).start();
+        frame.getContentPane().add(vncPanel, BorderLayout.CENTER);
+        frame.getContentPane().add(new JLabel("Custom Component"), BorderLayout.SOUTH);
+        frame.setSize(600, 600);
+        frame.setVisible(true);
+      }
+    });
+  }
+}

--- a/java/com/turbovnc/vncviewer/F8Menu.java
+++ b/java/com/turbovnc/vncviewer/F8Menu.java
@@ -142,7 +142,7 @@ public class F8Menu extends JPopupMenu implements ActionListener {
       cc.sizeWindow();
       firePopupMenuCanceled();
     } else if (actionMatch(ev, clipboard)) {
-      cc.clipboardDialog.showDialog(cc.viewport);
+      cc.clipboardDialog.showDialog(cc.viewport.frame);
     } else if (actionMatch(ev, grabKeyboard)) {
       cc.toggleKeyboardGrab();
     } else if (actionMatch(ev, f8)) {
@@ -174,14 +174,14 @@ public class F8Menu extends JPopupMenu implements ActionListener {
     		VncViewer.newViewer((VncViewer)cc.viewer);
     	}
     } else if (actionMatch(ev, options)) {
-      cc.options.showDialog(cc.viewport);
+      cc.options.showDialog(cc.viewport.frame);
     } else if (actionMatch(ev, info)) {
       cc.showInfo();
     } else if (actionMatch(ev, profile)) {
       if (cc.profileDialog.isVisible())
         cc.profileDialog.endDialog();
       else
-        cc.profileDialog.showDialog(cc.viewport);
+        cc.profileDialog.showDialog(cc.viewport.frame);
       cc.toggleProfile();
      } else if (actionMatch(ev, about)) {
       cc.showAbout();

--- a/java/com/turbovnc/vncviewer/F8Menu.java
+++ b/java/com/turbovnc/vncviewer/F8Menu.java
@@ -170,7 +170,9 @@ public class F8Menu extends JPopupMenu implements ActionListener {
       cc.losslessRefresh();
       firePopupMenuCanceled();
     } else if (!VncViewer.noNewConn.getValue() && actionMatch(ev, newConn)) {
-      VncViewer.newViewer(cc.viewer);
+    	if(cc.viewer instanceof VncViewer){
+    		VncViewer.newViewer((VncViewer)cc.viewer);
+    	}
     } else if (actionMatch(ev, options)) {
       cc.options.showDialog(cc.viewport);
     } else if (actionMatch(ev, info)) {

--- a/java/com/turbovnc/vncviewer/MacMenuBar.java
+++ b/java/com/turbovnc/vncviewer/MacMenuBar.java
@@ -42,7 +42,7 @@ public class MacMenuBar extends JMenuBar implements ActionListener {
       if (method.getName().equals("handleAbout")) {
         cc.showAbout();
       } else if (method.getName().equals("handlePreferences")) {
-        cc.options.showDialog(cc.viewport);
+        cc.options.showDialog(cc.viewport.frame);
       }
       return null;
     }
@@ -168,7 +168,7 @@ public class MacMenuBar extends JMenuBar implements ActionListener {
       cc.toggleToolbar();
       showToolbar.setSelected(cc.showToolbar);
     } else if (actionMatch(ev, clipboard)) {
-      cc.clipboardDialog.showDialog(cc.viewport);
+      cc.clipboardDialog.showDialog(cc.viewport.frame);
     } else if (actionMatch(ev, ctrlAltDel) && !cc.opts.viewOnly) {
       cc.writeKeyEvent(Keysyms.Control_L, true);
       cc.writeKeyEvent(Keysyms.Alt_L, true);
@@ -197,7 +197,7 @@ public class MacMenuBar extends JMenuBar implements ActionListener {
       if (cc.profileDialog.isVisible())
         cc.profileDialog.endDialog();
       else
-        cc.profileDialog.showDialog(cc.viewport);
+        cc.profileDialog.showDialog(cc.viewport.frame);
       cc.toggleProfile();
     }
   }

--- a/java/com/turbovnc/vncviewer/MacMenuBar.java
+++ b/java/com/turbovnc/vncviewer/MacMenuBar.java
@@ -186,7 +186,9 @@ public class MacMenuBar extends JMenuBar implements ActionListener {
     } else if (actionMatch(ev, losslessRefresh)) {
       cc.losslessRefresh();
     } else if (!VncViewer.noNewConn.getValue() && actionMatch(ev, newConn)) {
-      VncViewer.newViewer(cc.viewer);
+    	if(cc.viewer instanceof VncViewer){
+    		VncViewer.newViewer((VncViewer)cc.viewer);
+    	}
     } else if (!VncViewer.noNewConn.getValue() && actionMatch(ev, closeConn)) {
       cc.close();
     } else if (actionMatch(ev, info)) {

--- a/java/com/turbovnc/vncviewer/ServerDialog.java
+++ b/java/com/turbovnc/vncviewer/ServerDialog.java
@@ -140,7 +140,9 @@ class ServerDialog extends Dialog implements ActionListener {
     dlg.addWindowListener(new WindowAdapter() {
       public void windowClosing(WindowEvent e) {
         if (VncViewer.nViewers == 1) {
-          cc.viewer.exit(1);
+        	if(cc.viewer instanceof VncViewer){
+        		((VncViewer)cc.viewer).exit(1);
+        	}
         } else {
           ret = false;
           endDialog();
@@ -172,7 +174,9 @@ class ServerDialog extends Dialog implements ActionListener {
       endDialog();
     } else if (s instanceof JButton && (JButton)s == cancelButton) {
       if (VncViewer.nViewers == 1)
-        cc.viewer.exit(1);
+      	if(cc.viewer instanceof VncViewer){
+    		((VncViewer)cc.viewer).exit(1);
+    	}
       ret = false;
       endDialog();
     } else if (s instanceof JButton && (JButton)s == optionsButton) {
@@ -192,7 +196,9 @@ class ServerDialog extends Dialog implements ActionListener {
     if (serverName == null || serverName.equals("")) {
       vlog.error("No server name specified!");
       if (VncViewer.nViewers == 1)
-        cc.viewer.exit(1);
+      	if(cc.viewer instanceof VncViewer){
+    		((VncViewer)cc.viewer).exit(1);
+    	}
       ret = false;
       endDialog();
     }

--- a/java/com/turbovnc/vncviewer/Toolbar.java
+++ b/java/com/turbovnc/vncviewer/Toolbar.java
@@ -146,7 +146,9 @@ public class Toolbar extends JToolBar implements ActionListener {
         cc.writeKeyEvent(Keysyms.Control_L, false);
       }
     } else if (((AbstractButton)s).getName() == buttons[9]) {
-      VncViewer.newViewer(cc.viewer);
+    	if(cc.viewer instanceof VncViewer){
+    		VncViewer.newViewer((VncViewer)cc.viewer);
+    	}
     } else if (((AbstractButton)s).getName() == buttons[10]) {
       cc.close();
     }

--- a/java/com/turbovnc/vncviewer/Toolbar.java
+++ b/java/com/turbovnc/vncviewer/Toolbar.java
@@ -108,7 +108,7 @@ public class Toolbar extends JToolBar implements ActionListener {
   public void actionPerformed(ActionEvent e) {
     Object s = e.getSource();
     if (((AbstractButton)s).getName() == buttons[0]) {
-      cc.options.showDialog(cc.viewport);
+      cc.options.showDialog(cc.viewport.frame);
     } else if (((AbstractButton)s).getName() == buttons[1]) {
       cc.showInfo();
     } else if (((AbstractButton)s).getName() == buttons[2]) {

--- a/java/com/turbovnc/vncviewer/Viewport.java
+++ b/java/com/turbovnc/vncviewer/Viewport.java
@@ -91,9 +91,6 @@ public class Viewport implements Runnable {
     getContainer().add(tb, BorderLayout.PAGE_START);
     
     getContainer().add(sp, BorderLayout.CENTER);
-    if(useFrame){
-      frame.getContentPane().add(getContainer());
-    }
     
     if (VncViewer.os.startsWith("mac os x") && useFrame) {
       macMenu = new MacMenuBar(cc);

--- a/java/com/turbovnc/vncviewer/Viewport.java
+++ b/java/com/turbovnc/vncviewer/Viewport.java
@@ -67,7 +67,14 @@ public class Viewport extends JFrame implements Runnable {
     }
     tb = new Toolbar(cc);
     add(tb, BorderLayout.PAGE_START);
-    getContentPane().add(sp);
+    
+    if(cc.viewer instanceof VncViewer){
+    	getContentPane().add(sp);
+    }else{
+    	cc.viewer.add(sp);
+    	cc.viewer.revalidate();
+    }
+    
     if (VncViewer.os.startsWith("mac os x")) {
       macMenu = new MacMenuBar(cc);
       setJMenuBar(macMenu);

--- a/java/com/turbovnc/vncviewer/VncViewer.java
+++ b/java/com/turbovnc/vncviewer/VncViewer.java
@@ -313,9 +313,11 @@ public class VncViewer extends javax.swing.JApplet
 	  this(argv, null);
   }
   
-  private Container component;
+  private Container component = this;
   public VncViewer(String [] argv, Container component) {
-	this.component = component;
+    if(component != null){
+      this.component = component;
+    }
     applet = false;
 
     UserPreferences.load("global");
@@ -759,11 +761,7 @@ public class VncViewer extends javax.swing.JApplet
 
       try {
         if (cc == null){
-        	if(component == null){
-        		cc = new CConn(this, sock);
-        	}else{
         		cc = new CConn(component, sock);
-        	}
         }
         if (benchFile != null) {
           if (i < benchWarmup)

--- a/java/com/turbovnc/vncviewer/VncViewer.java
+++ b/java/com/turbovnc/vncviewer/VncViewer.java
@@ -309,7 +309,13 @@ public class VncViewer extends javax.swing.JApplet
     viewer.start();
   }
 
-  public VncViewer(String[] argv) {
+  public VncViewer(String [] argv){
+	  this(argv, null);
+  }
+  
+  private Container component;
+  public VncViewer(String [] argv, Container component) {
+	this.component = component;
     applet = false;
 
     UserPreferences.load("global");
@@ -752,8 +758,13 @@ public class VncViewer extends javax.swing.JApplet
       double tStart = 0.0, tTotal;
 
       try {
-        if (cc == null)
-          cc = new CConn(this, sock);
+        if (cc == null){
+        	if(component == null){
+        		cc = new CConn(this, sock);
+        	}else{
+        		cc = new CConn(component, sock);
+        	}
+        }
         if (benchFile != null) {
           if (i < benchWarmup)
             System.out.format("Benchmark warmup run %d\n", i + 1);


### PR DESCRIPTION
This was the easiest way I found to accomplish it without changing too much. The api change is compatible and any existing functionality should work (but didn't test much.)

You construct the VncViewer object with a swing container. This container is used as the parent for the Viewport. Most of the changes are because Viewport no longer extends JFrame.

An issue that isn't resolved is that if the vnc window is bigger than the provided component there is no scroll bar. 

If I make any more updates I'll let you know but I'm not actively looking at it.
