### PR TITLE
win: Send original key code instead of VK_PROCESSKEY in connection.

### DIFF
--- a/win/vncviewer/CMakeLists.txt
+++ b/win/vncviewer/CMakeLists.txt
@@ -61,10 +61,10 @@ if(TVNC_WINCONSOLE)
 endif()
 
 target_link_libraries(vncviewer zlib ${TJPEG_LIBRARY} fbx ws2_32.lib winmm.lib
-	htmlhelp.lib comctl32.lib)
+	htmlhelp.lib comctl32.lib imm32.lib)
 if(TVNC_WINCONSOLE)
 	target_link_libraries(cvncviewer zlib ${TJPEG_LIBRARY} fbx ws2_32.lib
-		winmm.lib htmlhelp.lib comctl32.lib)
+		winmm.lib htmlhelp.lib comctl32.lib imm32.lib)
 endif()
 
 install(TARGETS vncviewer DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/win/vncviewer/ClientConnection.cpp
+++ b/win/vncviewer/ClientConnection.cpp
@@ -140,6 +140,7 @@ void ClientConnection::Init(VNCviewerApp *pApp)
   m_hwnd1 = NULL;
   m_hwndscroll = NULL;
   m_hToolbar = NULL;
+  m_hIMC = NULL;
   m_desktopName = NULL;
   m_port = -1;
   m_serverInitiated = false;
@@ -535,6 +536,7 @@ void ClientConnection::CreateDisplay()
                         CW_USEDEFAULT, CW_USEDEFAULT, CW_USEDEFAULT,
                         CW_USEDEFAULT, m_hwndscroll, NULL,
                         m_pApp->m_instance, NULL);
+  m_hIMC = ImmAssociateContext(m_hwnd, NULL);
   m_opts.m_hWindow = m_hwnd;
   hotkeys.SetWindow(m_hwnd1);
   ShowWindow(m_hwnd, SW_HIDE);

--- a/win/vncviewer/ClientConnection.h
+++ b/win/vncviewer/ClientConnection.h
@@ -113,6 +113,7 @@ class ClientConnection : public omni_thread
     SOCKET m_sock;
     bool m_serverInitiated;
     HWND m_hwnd, m_hbands, m_hwnd1, m_hToolbar, m_hwndscroll;
+    HIMC m_hIMC;
 
     void Init(VNCviewerApp *pApp);
     void InitCapabilities();


### PR DESCRIPTION
When IME enabled, the original virtual key value is changed to
VK_PROCESSKEY by IME, and dispatch VK_PROCESSKEY to message loop.
However there is no need to process VK_PROCESSKEY for connection,
we should send original key code to remote and let remote to handle
possible VK_PROCESSKEY.

Scenario: Most Asian languages require IME installed to input language
specific characters. The hotkey to switch between IME and US-Keyboard
could be "ctrl+shift", "ctrl+space", or a single "shift". Thus, combo
key input like ctrl+shift+f may not be sent to remote as expected.

Signed-off-by: Colin Xu <colin.xu@gmail.com>