### PR TITLE
Additional Logging for PAM Authentication

### DIFF
--- a/unix/Xvnc/programs/Xserver/hw/vnc/auth.c
+++ b/unix/Xvnc/programs/Xserver/hw/vnc/auth.c
@@ -236,9 +236,9 @@ static void AuthPAMUserPwdRspFunc(rfbClientPtr cl)
 
   if (rfbPAMAuthenticate(cl, pamServiceName, userBuf, pwdBuf, &emsg)){
     rfbClientAuthSucceeded(cl, rfbAuthUnixLogin);
-	rfbLog("Successful PAM authentication for user '%s'\n", userBuf); 
+    rfbLog("Successful PAM authentication for user '%s'\n", userBuf); 
   } else {
-	rfbLog("Failed PAM authentication for user '%s'\n", userBuf); 
+    rfbLog("Failed PAM authentication for user '%s'\n", userBuf); 
     rfbClientAuthFailed(cl, (char *)emsg);
   }
 }

--- a/unix/Xvnc/programs/Xserver/hw/vnc/auth.c
+++ b/unix/Xvnc/programs/Xserver/hw/vnc/auth.c
@@ -234,10 +234,13 @@ static void AuthPAMUserPwdRspFunc(rfbClientPtr cl)
     }
   }
 
-  if (rfbPAMAuthenticate(cl, pamServiceName, userBuf, pwdBuf, &emsg))
+  if (rfbPAMAuthenticate(cl, pamServiceName, userBuf, pwdBuf, &emsg)){
     rfbClientAuthSucceeded(cl, rfbAuthUnixLogin);
-  else
+	rfbLog("Successful PAM authentication for user '%s'\n", userBuf); 
+  } else {
+	rfbLog("Failed PAM authentication for user '%s'\n", userBuf); 
     rfbClientAuthFailed(cl, (char *)emsg);
+  }
 }
 
 #endif


### PR DESCRIPTION
When enforcing PAM authentication on the vncserver, it would be very useful to know who is authenticating. This is especially true when enable-user-acl is set. This pull request contains simple logging for PAM authentication failures and successes. 

Thank you for a great VNC product, and thank you for considering my request