### PR TITLE
Server: show cursor to clients that don't control it

### DIFF
--- a/unix/Xvnc/programs/Xserver/hw/vnc/draw.c
+++ b/unix/Xvnc/programs/Xserver/hw/vnc/draw.c
@@ -15,6 +15,7 @@
  *                                                      All Rights Reserved.
  *  Copyright (C) 2012-2013, 2016 Pierre Ossman for Cendio AB.
  *                                All Rights Reserved.
+ *  Copyright (C) 2021 AnatoScope SA. All Rights Reserved.
  *
  *  This is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -122,7 +123,7 @@ static inline Bool is_visible(DrawablePtr drawable)
   BoxRec *boxTemp = REGION_EXTENTS(pScreen, reg);  \
   if ((boxTemp->x2 - boxTemp->x1) * (boxTemp->y2 - boxTemp->y1) != 0)  \
     for (clTemp = rfbClientHead; clTemp; clTemp = clTemp->next) {  \
-      if (!prfb->dontSendFramebufferUpdate ||  \
+      if (!prfb->dontSendFramebufferUpdate || prfb->cursorOwner != clTemp ||  \
           !clTemp->enableCursorShapeUpdates)  \
         REGION_UNION((pScreen), &clTemp->modifiedRegion,  \
                      &clTemp->modifiedRegion, reg);  \

--- a/unix/Xvnc/programs/Xserver/hw/vnc/rfb.h
+++ b/unix/Xvnc/programs/Xserver/hw/vnc/rfb.h
@@ -3,6 +3,7 @@
  */
 
 /*
+ *  Copyright (C) 2021 AnatoScope SA. All Rights Reserved.
  *  Copyright (C) 2010-2020 D. R. Commander.  All Rights Reserved.
  *  Copyright (C) 2011 Gernot Tenchio
  *  Copyright (C) 2011 Joel Martin
@@ -156,6 +157,8 @@ typedef struct {
                                         drawn */
   Bool dontSendFramebufferUpdate;    /* TRUE while removing or drawing the
                                         cursor */
+  struct rfbClientRec *cursorOwner;  /* The client that has moved the cursor
+                                        last */
   Bool blockUpdates;                 /* TRUE while resizing the screen */
 
   /* wrapped screen functions */


### PR DESCRIPTION
When multiple clients are connected and one of them
is moving the cursor, other clients should see an
image of the cursor moving. So it must be sent to
them via framebuffer updates. The client that moves
the cursor must not get it via framebuffer updates
(if it supports the local cursor of course).

Intended for collaborative sessions.

It seems that RealVNC has this feature.

Related to: https://github.com/novnc/noVNC/issues/974