### PR TITLE
Fix potential divide-by-zero in rfbserver.c

### DIFF
--- a/unix/Xvnc/programs/Xserver/hw/vnc/rfbserver.c
+++ b/unix/Xvnc/programs/Xserver/hw/vnc/rfbserver.c
@@ -2413,6 +2413,9 @@ Bool rfbSendRectEncodingRaw(rfbClientPtr cl, int x, int y, int w, int h)
   char *fbptr =
     (cl->fb + (rfbFB.paddedWidthInBytes * y) + (x * (rfbFB.bitsPerPixel / 8)));
 
+  if (!h || !w)
+	  return TRUE; /* nothing to send */
+  
   /* Flush the buffer to guarantee correct alignment for translateFn(). */
   if (ublen > 0) {
     if (!rfbSendUpdateBuf(cl))


### PR DESCRIPTION
LibVNC found a potential divide-by-zero issue that appears to also be present in TurboVNC's version of Xvnc. This change applies the same fix used by LibVNC.

Original issue: https://github.com/LibVNC/libvncserver/issues/409
CVE: https://nvd.nist.gov/vuln/detail/CVE-2020-25708