### PR TITLE
Server: Allow listening on unix domain sockets

### DIFF
--- a/doc/config.txt
+++ b/doc/config.txt
@@ -280,17 +280,30 @@ to start the TurboVNC Viewer without JPEG acceleration.
 	the ''turbovnc.via'' system property, expands patterns beginning with the "%"
 	character, and uses the resulting command line to establish the secure tunnel
 	to the VNC gateway.  If ''VNC_VIA_CMD'' is not set, then this command line
-	defaults to  ''/usr/bin/ssh -f -L %L:%H:%R %G sleep 20'' on Linux/Un*x and
-	Mac systems and ''ssh.exe -f -L %L:%H:%R %G sleep 20'' on Windows systems.
+	defaults to ''/usr/bin/ssh -ax -f -L %L:%H:%R %G sleep 20'' on Linux/Un*x and
+	Mac systems and ''ssh.exe -ax -f -L %L:%H:%R %G sleep 20'' on Windows systems.
 	{nl}{nl} \
 	When the ''-tunnel'' option is used along with the ''-extssh'' option, the
 	TurboVNC Viewer reads the ''VNC_TUNNEL_CMD'' environment variable or the
 	''turbovnc.tunnel'' system property, expands patterns beginning with the "%"
 	character, and uses the resulting command line to establish the secure tunnel
 	to the VNC host.  If ''VNC_TUNNEL_CMD'' is not set, then this command line
-	defaults to ''/usr/bin/ssh -f -L %L:localhost:%R %H sleep 20'' on Linux/Un*x
-	and Mac systems and ''ssh.exe -f -L %L:localhost:%R %H sleep 20'' on Windows
-	systems.
+	defaults to ''/usr/bin/ssh -ax -f -L %L:localhost:%R %H sleep 20''
+	on Linux/Un*x and Mac systems and
+	''ssh.exe -ax -f -L %L:localhost:%R %H sleep 20'' on Windows systems.
+	{nl}{nl} \
+	If a connection to a unix domain socket is made, the default value for
+	''VNC_TUNNEL_CMD'' is
+	''/usr/bin/ssh -ax -- %H exec socat stdio unix-connect:%R''
+	on Linux/Un*x and Mac systems and
+	''ssh.exe -ax -- %H exec socat stdio unix-connect:%R'' on Windows and the
+	default	value for ''VNC_VIA_CMD'' is
+	''/usr/bin/ssh -ax -J %G -- %H exec socat stdio unix-connect:%R'' on
+	Linux/Un*x and Mac systems and
+	''ssh.exe -ax -J %G -- %H exec socat stdio unix-connect:%R'' on Windows.
+	When the value (like the default values) does not contain the pattern ''%L'',
+	the TurboVNC viewer expect the command to connect it's standard input /
+	output to the socket.
 	{nl}{nl} \
 	The following patterns are recognized in the ''VNC_VIA_CMD'' and
 	''VNC_TUNNEL_CMD'' environment variables and their corresponding system
@@ -303,4 +316,4 @@ to start the TurboVNC Viewer without JPEG acceleration.
 	| ''%H'' | remote VNC host name or IP address (if using the ''-via'' \
 		option, then this is specified from the point of view of the gateway) |
 	| ''%L'' | local TCP port number |
-	| ''%R'' | remote TCP port number |
+	| ''%R'' | remote TCP port number or the escaped name of the unix domain socket |

--- a/java/com/turbovnc/network/StreamDescriptor.java
+++ b/java/com/turbovnc/network/StreamDescriptor.java
@@ -1,0 +1,224 @@
+/* Copyright (C) 2021 Steffen Kieß
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+ * USA.
+ */
+
+package com.turbovnc.network;
+
+import java.io.IOException;
+
+import java.nio.channels.*;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import com.turbovnc.rdr.*;
+
+// A FileDescriptor implementation which reads from an InputStream and writes
+// into an OutputStream.
+//
+// Because it is not possible to find out whether a read or write from an
+// InputStream / OutputStream will be blocking, reading and writing will be done
+// in background threads.
+public class StreamDescriptor implements FileDescriptor {
+
+  public StreamDescriptor(InputStream in, OutputStream out) {
+    inputStream = in;
+    outputStream = out;
+
+    inThread = new Thread() {
+      public void run() {
+        inThreadRun();
+      }
+    };
+    inThread.start();
+
+    outThread = new Thread() {
+      public void run() {
+        outThreadRun();
+      }
+    };
+    outThread.start();
+  }
+
+  public void close() {
+    try {
+      inputStream.close();
+      outputStream.close();
+    } catch (java.io.IOException e) {
+      throw new SystemException(e);
+    }
+  }
+
+  private void inThreadRun() {
+    while (true) {
+      synchronized (this) {
+        // Wait until data has been removed from input buffer
+        while (inPos != inLen) {
+          try {
+            wait();
+          } catch (InterruptedException e) {
+            throw new SystemException(e);
+          }
+        }
+        inLen = inPos = 0;
+      }
+
+      int n;
+      try {
+        n = inputStream.read(inBuffer, 0, inBuffer.length);
+      } catch (IOException e) {
+        synchronized (this) {
+          error = e;
+          notifyAll();
+          return;
+        }
+      }
+
+      synchronized (this) {
+        if (n < 0) { // EOF
+          inLen = -1;
+          notifyAll();
+          return;
+        } else {
+          inLen = n;
+          notifyAll();
+        }
+      }
+    }
+  }
+
+  public synchronized int read(byte[] buf, int bufPtr, int length) {
+    if (error != null)
+      throw new ErrorException("Connection encountered an error: "
+                               + error.getMessage());
+
+    if (length == 0)
+      return 0;
+
+    if (inPos == inLen)
+      throw new ErrorException("Attempted blocking read operation");
+
+    if (inLen == -1)
+      return 0; // EOF
+
+    int bytesToRead = Math.min(length, inLen - inPos);
+    System.arraycopy(inBuffer, inPos, buf, bufPtr, bytesToRead);
+    inPos += bytesToRead;
+    StreamDescriptor.this.notifyAll();
+
+    return bytesToRead;
+  }
+
+  private void outThreadRun() {
+    while (true) {
+      synchronized (this) {
+        // Wait until there is data in the output buffer
+        while (outLen == 0) {
+          try {
+            wait();
+          } catch (InterruptedException e) {
+            throw new SystemException(e);
+          }
+        }
+      }
+
+      try {
+        if (outLen == -1) { // EOF
+          outputStream.close();
+          return;
+        }
+
+        outputStream.write(outBuffer, 0, outLen);
+        outputStream.flush();
+      } catch (IOException e) {
+        synchronized (this) {
+          error = e;
+          notifyAll();
+          return;
+        }
+      }
+
+      synchronized (this) {
+        outLen = 0;
+        notifyAll();
+      }
+    }
+  }
+
+  public synchronized int write(byte[] buf, int bufPtr, int length) {
+    if (error != null)
+      throw new ErrorException("Connection encountered an error: "
+                               + error.getMessage());
+
+    if (length == 0)
+      return 0;
+
+    if (outLen == -1)
+      throw new ErrorException("Attempted write operation after sending EOF");
+
+    if (outLen != 0)
+      throw new ErrorException("Attempted blocking write operation");
+
+    int bytesToWrite = Math.min(length, outBuffer.length);
+    System.arraycopy(buf, bufPtr, outBuffer, 0, bytesToWrite);
+    outLen = bytesToWrite;
+    StreamDescriptor.this.notifyAll();
+
+    return bytesToWrite;
+  }
+
+  public synchronized int select(int interestOps, Integer timeout) {
+    if ((interestOps & ~(SelectionKey.OP_READ | SelectionKey.OP_WRITE)) != 0)
+      throw new ErrorException("Unexpected selection key");
+
+    while (true) {
+      if (error != null)
+        return 1;
+      if ((interestOps & SelectionKey.OP_READ) != 0 && inPos != inLen)
+        return 1;
+      if ((interestOps & SelectionKey.OP_WRITE) != 0 && outLen == 0)
+        return 1;
+
+      try {
+        if (timeout == null)
+          wait();
+        else if (timeout == 0)
+          return 0;
+        else
+          // Note: This might wait multiple times for timeout if the thread is
+          // woken up for other reasons.
+          wait(timeout);
+      } catch (InterruptedException e) {
+        throw new SystemException(e);
+      }
+    }
+  }
+
+  private InputStream inputStream;
+  private OutputStream outputStream;
+
+  private Thread inThread;
+  private byte[] inBuffer = new byte[65536];
+  private int inPos = 0;
+  private int inLen = 0;
+
+  private Thread outThread;
+  private byte[] outBuffer = new byte[65536];
+  private int outLen = 0;
+
+  private IOException error = null;
+}

--- a/java/com/turbovnc/network/StreamSocket.java
+++ b/java/com/turbovnc/network/StreamSocket.java
@@ -1,0 +1,79 @@
+/* Copyright (C) 2021 Steffen Kieß
+ *
+ * This is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this software; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301,
+ * USA.
+ */
+
+package com.turbovnc.network;
+
+import com.turbovnc.rdr.*;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+
+public class StreamSocket extends Socket {
+
+  // -=- StreamSocket
+
+  public StreamSocket(InputStream in, OutputStream out, boolean own) {
+    descriptor = new StreamDescriptor(in, out);
+    instream = new FdInStream(descriptor);
+    outstream = new FdOutStream(descriptor);
+    ownStreams = own;
+  }
+
+  public int getMyPort() {
+    return -1;
+  }
+
+  public String getPeerAddress() {
+    return "";
+  }
+
+  public String getPeerName() {
+    return "";
+  }
+
+  public int getPeerPort() {
+    return -1;
+  }
+
+  public String getPeerEndpoint() {
+    return "";
+  }
+
+  public boolean sameMachine() {
+    return false;
+  }
+
+  public void shutdown() {
+    super.shutdown();
+    descriptor.close();
+  }
+
+  public void close() {
+    descriptor.close();
+  }
+
+  public boolean isConnected() {
+    return true;
+  }
+
+  public int getSockPort() {
+    return -1;
+  }
+
+  private StreamDescriptor descriptor;
+}

--- a/java/com/turbovnc/rfb/Hostname.java
+++ b/java/com/turbovnc/rfb/Hostname.java
@@ -1,5 +1,6 @@
 /* Copyright (C) 2002-2005 RealVNC Ltd.  All Rights Reserved.
  * Copyright (C) 2012, 2016, 2018, 2020 D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021 Steffen Kieß
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -23,7 +24,18 @@ import com.turbovnc.rdr.*;
 
 public final class Hostname {
 
+  public static boolean isUnixDomain(String vncServerName) {
+    return vncServerName.indexOf(":/") >= 0;
+  }
+
   public static String getHost(String vncServerName) {
+    if (isUnixDomain(vncServerName)) {
+      int colonPos = vncServerName.indexOf(":/");
+      if (colonPos == 0)
+        return "localhost";
+      return vncServerName.substring(0, colonPos).replaceAll("\\s", "");
+    }
+
     int colonPos = vncServerName.lastIndexOf(':');
     int bracketPos = vncServerName.lastIndexOf(']');
     boolean doubleColon = false;
@@ -52,6 +64,9 @@ public final class Hostname {
   }
 
   public static int getPort(String vncServerName) {
+    if (isUnixDomain(vncServerName))
+      return -1;
+
     int colonPos = vncServerName.lastIndexOf(':');
     int bracketPos = vncServerName.lastIndexOf(']');
     boolean doubleColon = false;
@@ -89,6 +104,14 @@ public final class Hostname {
     } catch (NumberFormatException e) {
       throw new ErrorException("Invalid VNC server specified.");
     }
+  }
+
+  public static String getUnixDomainPath(String vncServerName) {
+    if (!isUnixDomain(vncServerName))
+      return null;
+
+    int colonPos = vncServerName.indexOf(":/");
+    return vncServerName.substring(colonPos + 1);
   }
 
   private Hostname() {}

--- a/java/com/turbovnc/rfb/Options.java
+++ b/java/com/turbovnc/rfb/Options.java
@@ -1,5 +1,6 @@
 /* Copyright (C) 2012-2013, 2015, 2017-2018, 2020 D. R. Commander.
  *                                                All Rights Reserved.
+ * Copyright (C) 2021 Steffen Kieß
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -20,6 +21,8 @@
 package com.turbovnc.rfb;
 
 import com.jcraft.jsch.Session;
+
+import com.turbovnc.network.Socket;
 
 public class Options {
 
@@ -59,6 +62,8 @@ public class Options {
     if (old.serverName != null)
       serverName = new String(old.serverName);
     shared = old.shared;
+    if (old.unixDomainPath != null)
+      unixDomainPath = new String(old.unixDomainPath);
 
     fsAltEnter = old.fsAltEnter;
     grabKeyboard = old.grabKeyboard;
@@ -85,6 +90,7 @@ public class Options {
 
     extSSH = old.extSSH;
     sendLocalUsername = old.sendLocalUsername;
+    stdioSocket = old.stdioSocket;
     sshSession = old.sshSession;
     sshTunnelActive = old.sshTunnelActive;
     if (old.sshUser != null) sshUser = new String(old.sshUser);
@@ -205,6 +211,7 @@ public class Options {
     printOpt("sendClipboard", sendClipboard);
     printOpt("serverName", serverName);
     printOpt("shared", shared);
+    printOpt("unixDomainPath", unixDomainPath);
 
     printOpt("fsAltEnter", fsAltEnter);
     printOpt("grabKeyboard", grabKeyboard);
@@ -304,6 +311,7 @@ public class Options {
   public boolean sendClipboard;
   public String serverName;
   public boolean shared;
+  public String unixDomainPath;
   // INPUT OPTIONS
   public boolean fsAltEnter;
   public int grabKeyboard;
@@ -329,6 +337,7 @@ public class Options {
   // SECURITY AND AUTHENTICATION OPTIONS
   public boolean extSSH;
   public boolean sendLocalUsername;
+  public Socket stdioSocket;
   public Session sshSession;
   public boolean sshTunnelActive;
   public String sshUser;

--- a/java/com/turbovnc/rfb/Params.java
+++ b/java/com/turbovnc/rfb/Params.java
@@ -2,6 +2,7 @@
  * Copyright 2004-2005 Cendio AB.
  * Copyright (C) 2012-2018, 2020 D. R. Commander.  All Rights Reserved.
  * Copyright (C) 2011-2012, 2016 Brian P. Hinz
+ * Copyright (C) 2021 Steffen Kieß
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -450,7 +451,8 @@ public final class Params {
   public static StringParameter vncServerName =
   new StringParameter("Server",
   "The VNC server to which to connect.  This can be specified in the " +
-  "format {host}[:{display_number}] or {host}::{port}, where {host} is the " +
+  "format {host}[:{display_number}], {host}::{port} or" +
+  " {host}:/{unix_socket_path}, where {host} is the " +
   "host name or IP address of the machine on which the VNC server is " +
   "running (the \"VNC host\"), {display_number} is an optional X display " +
   (Utils.getBooleanProperty("turbovnc.sessmgr", true) ?
@@ -887,7 +889,9 @@ public final class Params {
   "the VNC host, so you do not need to specify it separately.  When using " +
   "the Tunnel parameter, the VNC host can be prefixed with {user}@ to " +
   "indicate that user name {user} (default = local user name) should be " +
-  "used when authenticating with the SSH server.\n " +
+  "used when authenticating with the SSH server. This parameter is implied " +
+  "if a connection to a unix socket path with a non-localhost server name is " +
+  "used and the Via parameter is not set.\n " +
 
   "When using the TurboVNC Session Manager, this parameter is effectively " +
   "set unless the SessMgrAuto parameter is disabled.", false);

--- a/java/com/turbovnc/vncviewer/CConn.java
+++ b/java/com/turbovnc/vncviewer/CConn.java
@@ -2,6 +2,7 @@
  * Copyright 2009-2011 Pierre Ossman <ossman@cendio.se> for Cendio AB
  * Copyright (C) 2011-2021 D. R. Commander.  All Rights Reserved.
  * Copyright (C) 2011-2015 Brian P. Hinz
+ * Copyright (C) 2021 Steffen Kieß
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -120,6 +121,7 @@ public class CConn extends CConnection implements UserPasswdGetter,
           !Params.alwaysShowConnectionDialog.getValue()) {
         if (opts.via == null || opts.via.indexOf(':') < 0) {
           port = opts.port = Hostname.getPort(opts.serverName);
+          opts.unixDomainPath = Hostname.getUnixDomainPath(opts.serverName);
           serverName = opts.serverName = Hostname.getHost(opts.serverName);
         }
       } else {
@@ -133,7 +135,14 @@ public class CConn extends CConnection implements UserPasswdGetter,
         serverName = opts.serverName;
       }
 
-      if (opts.via != null && opts.via.indexOf(':') >= 0) {
+      // A unix domain connection to non-localhost requires a tunnel
+      if (opts.unixDomainPath != null && opts.via == null && !opts.tunnel &&
+          !opts.serverName.equals(""))
+        opts.tunnel = true;
+
+      if (opts.unixDomainPath != null && opts.via == null && !opts.tunnel) {
+        opts.stdioSocket = Tunnel.connectUnixDirect(opts.unixDomainPath);
+      } else if (opts.via != null && opts.via.indexOf(':') >= 0) {
         port = Hostname.getPort(opts.via);
         serverName = Hostname.getHost(opts.via);
       } else if (opts.via != null || opts.tunnel ||
@@ -166,15 +175,17 @@ public class CConn extends CConnection implements UserPasswdGetter,
         }
         try {
           Tunnel.createTunnel(opts);
-          port = Hostname.getPort(opts.serverName);
-          serverName = Hostname.getHost(opts.serverName);
+          if (opts.stdioSocket == null) {
+            port = Hostname.getPort(opts.serverName);
+            serverName = Hostname.getHost(opts.serverName);
+          }
         } catch (Exception e) {
           throw new ErrorException("Could not create SSH tunnel:\n" +
                                    e.getMessage());
         }
       }
 
-      if (port == 0) {
+      if (port == 0 && opts.stdioSocket == null) {
         try {
           // TurboVNC Session Manager
           String session = SessionManager.createSession(opts);
@@ -190,8 +201,16 @@ public class CConn extends CConnection implements UserPasswdGetter,
         }
       }
 
-      sock = new TcpSocket(serverName, port);
-      vlog.info("connected to host " + serverName + " port " + port);
+      if (opts.stdioSocket == null) {
+        sock = new TcpSocket(serverName, port);
+        vlog.info("connected to host " + serverName + " port " + port);
+      } else {
+        sock = opts.stdioSocket;
+        if (opts.serverName.equals("localhost"))
+          vlog.info("connected to socket " + opts.unixDomainPath);
+        else
+          vlog.info("connected over ssh to host " + opts.serverName + " socket " + opts.unixDomainPath);
+      }
     }
 
     if (benchmark) {
@@ -1450,6 +1469,10 @@ public class CConn extends CConnection implements UserPasswdGetter,
     if (opts.sshSession != null) {
       opts.sshSession.disconnect();
       opts.sshSession = null;
+    }
+    if (opts.stdioSocket != null) {
+      opts.stdioSocket.shutdown();
+      opts.stdioSocket = null;
     }
     if (reader != null)
       reader.close();

--- a/java/com/turbovnc/vncviewer/ServerDialog.java
+++ b/java/com/turbovnc/vncviewer/ServerDialog.java
@@ -1,6 +1,7 @@
 /* Copyright (C) 2002-2005 RealVNC Ltd.  All Rights Reserved.
  * Copyright (C) 2011-2013 Brian P. Hinz
  * Copyright (C) 2012-2015, 2018, 2020 D. R. Commander.  All Rights Reserved.
+ * Copyright (C) 2021 Steffen Kieß
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -232,6 +233,7 @@ class ServerDialog extends Dialog implements ActionListener {
           opts.serverName = Hostname.getHost(serverName);
         }
         opts.port = Hostname.getPort(serverName);
+        opts.unixDomainPath = Hostname.getUnixDomainPath(serverName);
       }
 
       // Update the history list

--- a/java/com/turbovnc/vncviewer/Tunnel.java
+++ b/java/com/turbovnc/vncviewer/Tunnel.java
@@ -3,6 +3,7 @@
  *  Copyright (C) 2012-2015, 2017-2018, 2020 D. R. Commander.
  *                                           All Rights Reserved.
  *  Copyright (C) 2012, 2016 Brian P. Hinz.  All Rights Reserved.
+ *  Copyright (C) 2021 Steffen Kieß
  *
  *  This is free software; you can redistribute it and/or modify
  *  it under the terms of the GNU General Public License as published by
@@ -26,7 +27,7 @@
 
 package com.turbovnc.vncviewer;
 
-import java.io.File;
+import java.io.*;
 import java.util.*;
 
 import com.turbovnc.rfb.*;
@@ -46,9 +47,16 @@ public class Tunnel {
     String gatewayHost;
     String remoteHost;
 
-    localPort = TcpSocket.findFreeTcpPort();
-    if (localPort == 0)
-      throw new ErrorException("Could not obtain free TCP port");
+    String pattern = null;
+    if (opts.tunnel) {
+      pattern = System.getProperty("turbovnc.tunnel");
+      if (pattern == null)
+        pattern = System.getenv("VNC_TUNNEL_CMD");
+    } else {
+      pattern = System.getProperty("turbovnc.via");
+      if (pattern == null)
+        pattern = System.getenv("VNC_VIA_CMD");
+    }
 
     if (opts.tunnel) {
       gatewayHost = Hostname.getHost(opts.serverName);
@@ -63,29 +71,46 @@ public class Tunnel {
     else
       remotePort = Hostname.getPort(opts.serverName);
 
-    String pattern = null;
-    if (opts.tunnel) {
-      pattern = System.getProperty("turbovnc.tunnel");
-      if (pattern == null)
-        pattern = System.getenv("VNC_TUNNEL_CMD");
-    } else {
-      pattern = System.getProperty("turbovnc.via");
-      if (pattern == null)
-        pattern = System.getenv("VNC_VIA_CMD");
-    }
+    if (opts.unixDomainPath != null &&
+        (pattern == null || pattern.indexOf("%L") < 0)) {
+      // Connect to unix domain socket using stdio-based forwarding
 
-    if (opts.extSSH || (pattern != null && pattern.length() > 0))
-      createTunnelExt(gatewayHost, remoteHost, remotePort, localPort, pattern,
-                      opts);
-    else {
-      vlog.debug("Opening SSH tunnel through gateway " + gatewayHost);
-      if (opts.sshSession == null)
-        createTunnelJSch(gatewayHost, opts);
-      vlog.debug("Forwarding local port " + localPort + " to " + remoteHost +
-                 ":" + remotePort + " (relative to gateway)");
-      opts.sshSession.setPortForwardingL(localPort, remoteHost, remotePort);
+      if (opts.extSSH || (pattern != null && pattern.length() > 0))
+        opts.stdioSocket = createTunnelExtStdio(gatewayHost, remoteHost,
+                                                opts.unixDomainPath, pattern,
+                                                opts);
+      else {
+        vlog.debug("Opening SSH stdio tunnel through gateway " + gatewayHost);
+        opts.stdioSocket = createTunnelJSchStdio(opts.serverName, opts);
+      }
+    } else {
+      // Forward to a local TCP port and connect to this port
+
+      String unixDomainPath = null;
+      if (opts.unixDomainPath != null) {
+        // Escape the unix domain path once: It will only be interpreted by
+        // ArgumentTokenizer.tokenize().
+        // Expansions are not supported in this case
+        unixDomainPath = escapeUnixDomainPath(opts.unixDomainPath, false);
+      }
+
+      localPort = TcpSocket.findFreeTcpPort();
+      if (localPort == 0)
+        throw new ErrorException("Could not obtain free TCP port");
+
+      if (opts.extSSH || (pattern != null && pattern.length() > 0))
+        createTunnelExt(gatewayHost, remoteHost, remotePort, unixDomainPath,
+                        localPort, pattern, opts);
+      else {
+        vlog.debug("Opening SSH tunnel through gateway " + gatewayHost);
+        if (opts.sshSession == null)
+          createTunnelJSch(gatewayHost, opts);
+        vlog.debug("Forwarding local port " + localPort + " to " + remoteHost +
+                   ":" + remotePort + " (relative to gateway)");
+        opts.sshSession.setPortForwardingL(localPort, remoteHost, remotePort);
+      }
+      opts.serverName = "localhost::" + localPort;
     }
-    opts.serverName = "localhost::" + localPort;
     opts.sshTunnelActive = true;
   }
 
@@ -93,6 +118,52 @@ public class Tunnel {
 
   protected static void createTunnelJSch(String host, Options opts)
                                          throws Exception {
+    opts.sshSession = openJSchConnection(host, opts, null);
+  }
+
+  static Socket createTunnelJSchStdio(String remoteHost, Options opts)
+                                      throws Exception {
+    String command = "exec socat stdio unix-connect:\\\"" +
+      escapeUnixDomainPath(opts.unixDomainPath, true) + "\\\"";
+
+    JSchProxy proxy = null;
+    if (opts.via != null)
+      proxy = new JSchProxy(opts.via, opts);
+
+    vlog.debug("Opening SSH tunnel to " + remoteHost);
+
+    Session session = openJSchConnection(remoteHost, opts, proxy);
+
+    ChannelExec channelExec = (ChannelExec)session.openChannel("exec");
+    channelExec.setCommand(command);
+    final InputStream stdout = channelExec.getInputStream();
+    final InputStream stderr = channelExec.getErrStream();
+    final OutputStream stdin = channelExec.getOutputStream();
+    channelExec.connect();
+
+    // Copy stderr from remote process to stderr
+    Thread thread = new Thread() {
+        public void run() {
+          byte[] buffer = new byte[1024];
+          try {
+            while (true) {
+              int len = stderr.read(buffer, 0, buffer.length);
+              if (len < 0)
+                return;
+              System.err.write(buffer, 0, len);
+            }
+          } catch (IOException e) {
+            throw new ErrorException("Error reading error stream: " + e.getMessage());
+          }
+        }
+      };
+    thread.start();
+
+    return new StreamSocket(stdout, stdin, true);
+  }
+
+  private static Session openJSchConnection(String host, Options opts,
+                                            Proxy proxy) throws Exception {
     JSch jsch = new JSch();
     JSch.setLogger(LOGGER);
     String homeDir = new String("");
@@ -216,21 +287,25 @@ public class Tunnel {
                                  privateKey.getAbsolutePath() + ":\n" +
                                  e.getMessage());
       }
-   }
+    }
 
-    opts.sshSession = jsch.getSession(user, host, port);
+    Session session = jsch.getSession(user, host, port);
+    if (proxy != null)
+      session.setProxy(proxy);
     // OpenSSHConfig doesn't recognize StrictHostKeyChecking
-    if (opts.sshSession.getConfig("StrictHostKeyChecking") == null)
-      opts.sshSession.setConfig("StrictHostKeyChecking", "ask");
-    opts.sshSession.setConfig("MaxAuthTries", "3");
+    if (session.getConfig("StrictHostKeyChecking") == null)
+      session.setConfig("StrictHostKeyChecking", "ask");
+    session.setConfig("MaxAuthTries", "3");
     String auth = System.getProperty("turbovnc.sshauth");
     if (auth == null)
       auth = "publickey,keyboard-interactive,password";
-    opts.sshSession.setConfig("PreferredAuthentications", auth);
+    session.setConfig("PreferredAuthentications", auth);
     PasswdDialog dlg = new PasswdDialog(new String("SSH Authentication"),
                                         true, user, false, true, -1);
-    opts.sshSession.setUserInfo(dlg);
-    opts.sshSession.connect();
+    session.setUserInfo(dlg);
+    session.connect();
+
+    return session;
   }
 
   /* Create a tunnel using an external SSH client.  This supports the same
@@ -240,19 +315,24 @@ public class Tunnel {
   private static final String DEFAULT_SSH_CMD =
     (Utils.isWindows() ? "ssh.exe" : "/usr/bin/ssh");
   private static final String DEFAULT_TUNNEL_CMD =
-    DEFAULT_SSH_CMD + " -f -L %L:localhost:%R %H sleep 20";
+    DEFAULT_SSH_CMD + " -ax -f -L %L:localhost:%R %H sleep 20";
   private static final String DEFAULT_VIA_CMD =
-    DEFAULT_SSH_CMD + " -f -L %L:%H:%R %G sleep 20";
+    DEFAULT_SSH_CMD + " -ax -f -L %L:%H:%R %G sleep 20";
+  private static final String DEFAULT_TUNNEL_CMD_UNIX =
+    DEFAULT_SSH_CMD + " -ax -- %H exec socat stdio unix-connect:%R";
+  private static final String DEFAULT_VIA_CMD_UNIX =
+    DEFAULT_SSH_CMD + " -ax -J %G -- %H exec socat stdio unix-connect:%R";
 
   public static void createTunnelExt(String gatewayHost, String remoteHost,
-                                     int remotePort, int localPort,
-                                     String pattern, Options opts)
-                                     throws Exception {
+                                     int remotePort, String unixDomainPath,
+                                     int localPort, String pattern,
+                                     Options opts) throws Exception {
     if (pattern == null || pattern.length() < 1)
       pattern = (opts.tunnel ? DEFAULT_TUNNEL_CMD : DEFAULT_VIA_CMD);
 
     String command = fillCmdPattern(pattern, gatewayHost, remoteHost,
-                                    remotePort, localPort, opts);
+                                    remotePort, unixDomainPath, localPort,
+                                    opts, false);
 
     vlog.debug("SSH command line: " + command);
     List<String> args = ArgumentTokenizer.tokenize(command);
@@ -265,9 +345,50 @@ public class Tunnel {
       throw new ErrorException("External SSH error");
   }
 
+  static Socket createTunnelExtStdio(String gatewayHost, String remoteHost,
+                                     String unixDomainPath, String pattern,
+                                     Options opts) throws Exception {
+    if (pattern == null || pattern.length() < 1)
+      pattern = (opts.tunnel ? DEFAULT_TUNNEL_CMD_UNIX : DEFAULT_VIA_CMD_UNIX);
+
+    // Escape the unix domain path twice: Once it will be interpreted by
+    // ArgumentTokenizer.tokenize(), once by the remote shell
+    String path = escapeUnixDomainPath(unixDomainPath, true);
+    path = escapeUnixDomainPath(path, false);
+
+    String command = fillCmdPattern(pattern, gatewayHost, remoteHost, -1,
+                                    path, -1, opts, true);
+
+    vlog.debug("SSH command line (stdio): " + command);
+    List<String> args = ArgumentTokenizer.tokenize(command);
+    ProcessBuilder pb = new ProcessBuilder(args);
+    pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+    Process p = pb.start();
+    if (p == null)
+      throw new ErrorException("External SSH error");
+    return new StreamSocket(p.getInputStream(), p.getOutputStream(), true);
+  }
+
+  static Socket connectUnixDirect(String unixDomainPath) {
+    String socketPath = expandUnixDomainPathLocal(unixDomainPath);
+
+    vlog.debug("Connecting to socket: " + socketPath);
+    try {
+      ProcessBuilder pb = new ProcessBuilder("socat", "stdio", "unix-connect:\"" + socketPath + "\"");
+      pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+      Process p = pb.start();
+      if (p == null)
+        throw new ErrorException("socat error");
+      return new StreamSocket(p.getInputStream(), p.getOutputStream(), true);
+    } catch (Exception e) {
+      throw new ErrorException("Could start socat:\n" + e.getMessage());
+    }
+  }
+
   private static String fillCmdPattern(String pattern, String gatewayHost,
                                        String remoteHost, int remotePort,
-                                       int localPort, Options opts) {
+                                       String unixDomainPath, int localPort,
+                                       Options opts, boolean stdio) {
     int i, j;
     boolean hFound = false, gFound = false, rFound = false, lFound = false;
     String command = "";
@@ -287,7 +408,10 @@ public class Tunnel {
             gFound = true;
             continue;
           case 'R':
-            command += remotePort;
+            if (unixDomainPath != null)
+              command += unixDomainPath;
+            else
+              command += remotePort;
             rFound = true;
             continue;
           case 'L':
@@ -299,13 +423,92 @@ public class Tunnel {
       command += pattern.charAt(i);
     }
 
-    if (!hFound || !rFound || !lFound)
+    if (!hFound || !rFound || (!lFound && !stdio))
       throw new ErrorException("%H, %R or %L absent in tunneling command template.");
 
     if (!opts.tunnel && !gFound)
       throw new ErrorException("%G pattern absent in tunneling command template.");
 
     return command;
+  }
+
+  // Escape the string for a posix shell or for ArgumentTokenizer.tokenize().
+  // Expand %d to the remote home directory, %i to the remote (numeric) user ID
+  // and %u to the remote username.
+  private static String escapeUnixDomainPath(String s, boolean expandTokens) {
+    String result = "'";
+
+    for (int i = 0; i < s.length(); i++) {
+      if (s.charAt(i) == '\'') {
+        // Replace ' by '"'"'
+        result += "'\"'\"'";
+        continue;
+      }
+      if (expandTokens && s.charAt(i) == '%') {
+        switch (s.charAt(++i)) {
+          case '%':
+            break;
+          case 'd':
+            result += "'\"$HOME\"'";
+            continue;
+          case 'i':
+            result += "'\"$(id -u)\"'";
+            continue;
+          case 'u':
+            result += "'\"$(id -u -n)\"'";
+            continue;
+          default:
+            throw new ErrorException("Invalid % sequence in unix domain path: %" + s.charAt(i));
+        }
+      }
+      result += s.charAt(i);
+    }
+
+    result += "'";
+    return result;
+  }
+
+  // Expand a unix domain path similar to escapeUnixDomainPath, but do the
+  // expansion locally
+  private static String expandUnixDomainPathLocal(String s) {
+    String result = "";
+
+    for (int i = 0; i < s.length(); i++) {
+      if (s.charAt(i) == '%') {
+        switch (s.charAt(++i)) {
+          case '%':
+            break;
+          case 'd':
+            result += System.getProperty("user.home");
+            continue;
+          case 'i':
+            try {
+              ProcessBuilder pb = new ProcessBuilder("id", "-u");
+              pb.redirectInput(ProcessBuilder.Redirect.INHERIT);
+              pb.redirectError(ProcessBuilder.Redirect.INHERIT);
+              Process p = pb.start();
+              if (p == null)
+                throw new ErrorException("error calling 'id -u'");
+              String id = new BufferedReader(new InputStreamReader(p.getInputStream())).readLine();
+              p.getOutputStream().close();
+              p.waitFor();
+              result += id;
+            } catch (Exception e) {
+              throw new ErrorException("Could run 'id -u':\n" +
+                                       e.getMessage());
+            }
+            continue;
+          case 'u':
+            result += System.getProperty("user.name");
+            continue;
+          default:
+            throw new ErrorException("Invalid % sequence in unix domain path: %" + s.charAt(i));
+        }
+      }
+      result += s.charAt(i);
+    }
+
+    return result;
   }
 
   // JSch logging interface
@@ -340,6 +543,56 @@ public class Tunnel {
       }
     }
   };
+
+  static class JSchProxy implements com.jcraft.jsch.Proxy {
+    Session outerSession;
+    ChannelDirectTCPIP channel;
+    PipedOutputStream toRemotePipeOut;
+    PipedInputStream fromRemotePipeIn;
+
+    public JSchProxy(String gatewayHost, Options opts) throws Exception {
+      vlog.debug("Opening outer SSH tunnel to " + gatewayHost);
+      outerSession = Tunnel.openJSchConnection(gatewayHost, opts, null);
+    }
+
+    public void connect(SocketFactory socket_factory, String host, int port, int timeout) throws Exception {
+      vlog.debug("Connecting over tunnel to " + host + ":" + port);
+      channel = (ChannelDirectTCPIP)outerSession.openChannel("direct-tcpip");
+      channel.setHost(host);
+      channel.setPort(port);
+      PipedInputStream toRemotePipeIn = new PipedInputStream();
+      toRemotePipeOut = new PipedOutputStream(toRemotePipeIn);
+      fromRemotePipeIn = new PipedInputStream();
+      PipedOutputStream fromRemotePipeOut = new PipedOutputStream(fromRemotePipeIn);
+      channel.setInputStream(toRemotePipeIn);
+      channel.setOutputStream(fromRemotePipeOut);
+      channel.connect();
+    }
+
+    public InputStream getInputStream() {
+      return fromRemotePipeIn;
+    }
+
+    public OutputStream getOutputStream() {
+      return toRemotePipeOut;
+    }
+
+    public java.net.Socket getSocket() {
+      return null;
+    }
+
+    public void close() {
+      if (channel != null)
+        channel.disconnect();
+      channel = null;
+      fromRemotePipeIn = null;
+      toRemotePipeOut = null;
+    }
+
+    public void closeOuter() {
+      outerSession.disconnect();
+    }
+  }
 
   protected Tunnel() {}
   static LogWriter vlog = new LogWriter("Tunnel");

--- a/java/com/turbovnc/vncviewer/VncViewer.java
+++ b/java/com/turbovnc/vncviewer/VncViewer.java
@@ -2,6 +2,7 @@
  * Copyright 2011 Pierre Ossman <ossman@cendio.se> for Cendio AB
  * Copyright (C) 2011-2018, 2020 D. R. Commander.  All Rights Reserved.
  * Copyright (C) 2011-2013, 2016 Brian P. Hinz
+ * Copyright (C) 2021 Steffen Kieß
  *
  * This is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -537,6 +538,7 @@ public class VncViewer implements Runnable, OptionsDialogCallback {
     sock = sock_;
     opts.serverName = null;
     opts.port = -1;
+    opts.unixDomainPath = null;
   }
 
   public static void newViewer(VncViewer oldViewer, Socket sock,

--- a/unix/Xvnc/programs/Xserver/Xvnc.man.in
+++ b/unix/Xvnc/programs/Xserver/Xvnc.man.in
@@ -184,6 +184,17 @@ TCP port that the server should use when listening for connections from normal
 VNC viewers.
 
 .TP
+\fB\-rfbunixpath\fR \fIpath\fR
+Specifies the path of a Unix domain socket on which Xvnc listens for
+connections from viewers.  Specifying this option will disable listening for
+TCP connections.
+
+.TP
+\fB\-rfbunixmode\fR \fImode\fR
+Specifies the mode of the Unix domain socket.  The value has to be specified as
+an octal number.  The default is 0600.
+
+.TP
 \fB\-rfbwait\fR \fItime\fR
 Maximum time, in milliseconds, to wait for a send/receive operation to/from a
 connected viewer to complete [default: 20000].

--- a/unix/Xvnc/programs/Xserver/hw/vnc/init.c
+++ b/unix/Xvnc/programs/Xserver/hw/vnc/init.c
@@ -5,6 +5,7 @@
  */
 
 /*
+ *  Copyright (C) 2021 Steffen Kieß
  *  Copyright (C) 2009-2021 D. R. Commander.  All Rights Reserved.
  *  Copyright (C) 2010 University Corporation for Atmospheric Research.
  *                     All Rights Reserved.
@@ -361,6 +362,22 @@ int ddxProcessArgument(int argc, char *argv[], int i)
   if (strcasecmp(argv[i], "-rfbport") == 0) {  /* -rfbport port */
     REQUIRE_ARG();
     rfbPort = atoi(argv[i + 1]);
+    return 2;
+  }
+
+  if (strcasecmp(argv[i], "-rfbunixpath") == 0) {  /* -rfbunixpath path */
+    REQUIRE_ARG();
+    rfbUnixPath = argv[i + 1];
+    return 2;
+  }
+
+  if (strcasecmp(argv[i], "-rfbunixmode") == 0) {  /* -rfbunixmode mode */
+    char *ptr;
+    REQUIRE_ARG();
+    rfbUnixMode = strtol(argv[i + 1], &ptr, 8);
+    if (argv[i + 1] + strlen(argv[i + 1]) != ptr || rfbUnixMode < 0 ||
+        rfbUnixMode > 0777)
+      FatalError("Invalid -rfbunixmode parameter\n");
     return 2;
   }
 
@@ -1551,6 +1568,9 @@ void ddxGiveUp(enum ExitCode error)
     sprintf(unixSocketName, "/tmp/.X11-unix/X%s", display);
     unlink(unixSocketName);
   }
+  if (rfbUnixPath && rfbUnixSocketCreated) {
+    unlink(rfbUnixPath);
+  }
 }
 
 
@@ -1645,6 +1665,8 @@ void ddxUseMsg(void)
   ErrorF("                       mouse button)\n");
   ErrorF("-noreverse             disable reverse connections\n");
   ErrorF("-rfbport port          TCP port for RFB protocol\n");
+  ErrorF("-rfbunixpath path      Unix domain socket path for RFB protocol\n");
+  ErrorF("-rfbunixmode mode      Mode for unix domain socket\n");
   ErrorF("-rfbwait time          max time in ms to wait for a send/receive operation\n");
   ErrorF("                       to/from a connected viewer to complete [default: %d]\n",
          DEFAULT_MAX_CLIENT_WAIT);

--- a/unix/Xvnc/programs/Xserver/hw/vnc/rfb.h
+++ b/unix/Xvnc/programs/Xserver/hw/vnc/rfb.h
@@ -3,6 +3,7 @@
  */
 
 /*
+ *  Copyright (C) 2021 Steffen Kieß
  *  Copyright (C) 2010-2021 D. R. Commander.  All Rights Reserved.
  *  Copyright (C) 2011, 2015 Pierre Ossman for Cendio AB.  All Rights Reserved.
  *  Copyright (C) 2011 Gernot Tenchio
@@ -932,6 +933,9 @@ extern int rfbMaxClientConnections;
 extern int rfbMaxClientWait;
 
 extern int rfbPort;
+extern const char *rfbUnixPath;
+extern int rfbUnixMode;
+extern Bool rfbUnixSocketCreated;
 extern int rfbListenSock;
 
 extern void rfbInitSockets(void);
@@ -947,6 +951,7 @@ extern int ReadExactTimeout(rfbClientPtr cl, char *buf, int len, int timeout);
 extern int SkipExact(rfbClientPtr cl, int len);
 extern int WriteExact(rfbClientPtr cl, char *buf, int len);
 extern int ListenOnTCPPort(int port);
+extern int ListenOnUnixDomainSocket(const char *path, int mode);
 extern int ConnectToTcpAddr(char *host, int port);
 
 extern const char *sockaddr_string(rfbSockAddr *addr, char *buf, int len);

--- a/unix/Xvnc/programs/Xserver/hw/vnc/sockets.c
+++ b/unix/Xvnc/programs/Xserver/hw/vnc/sockets.c
@@ -19,6 +19,7 @@
  */
 
 /*
+ *  Copyright (C) 2021 Steffen Kieß
  *  Copyright (C) 2012-2020 D. R. Commander.  All Rights Reserved.
  *  Copyright (C) 2011 Gernot Tenchio
  *  Copyright (C) 2011 Joel Martin
@@ -46,8 +47,10 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/time.h>
+#include <sys/un.h>
 #include <arpa/inet.h>
 #include <netinet/tcp.h>
 #include <netdb.h>
@@ -73,10 +76,18 @@ int deny_severity = LOG_WARNING;
 int rfbMaxClientWait = DEFAULT_MAX_CLIENT_WAIT;
 
 int rfbPort = 0;
+const char *rfbUnixPath = NULL;
+int rfbUnixMode = 0600;
+Bool rfbUnixSocketCreated = FALSE;
 int rfbListenSock = -1;
 int rfbMaxClientConnections = DEFAULT_MAX_CONNECTIONS;
 
 extern unsigned long long sendBytes;
+
+/* from log.c */
+void
+AbortServer(void)
+    _X_NORETURN;
 
 static void rfbSockNotify(int fd, int ready, void *data);
 
@@ -137,6 +148,24 @@ void rfbInitSockets(void)
     return;
   }
 
+  if (rfbUnixPath) {
+    rfbLog(
+        "Listening for VNC connections on unix domain socket %s (mode %04o)\n",
+        rfbUnixPath, rfbUnixMode);
+
+    if ((rfbListenSock = ListenOnUnixDomainSocket(rfbUnixPath, rfbUnixMode)) <
+        0) {
+      rfbLogPerror("ListenOnUnixDomainSocket");
+      AbortServer(); /* Clean up lock file and X11 socket file and exit */
+    }
+
+    /* Make sure that ddxGiveUp() will remove the socket */
+    rfbUnixSocketCreated = TRUE;
+
+    SetNotifyFd(rfbListenSock, rfbSockNotify, X_NOTIFY_READ, "UNIX");
+    return;
+  }
+
   if (rfbPort == 0)
     rfbPort = 5900 + atoi(display);
 
@@ -173,11 +202,13 @@ static void rfbSockNotify(int fd, int ready, void *data)
       return;
     }
 
-    if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&one,
-                   sizeof(one)) < 0) {
-      rfbLogPerror("rfbSockNotify: setsockopt");
-      close(sock);
-      return;
+    if (!data) {
+      if (setsockopt(sock, IPPROTO_TCP, TCP_NODELAY, (char *)&one,
+                     sizeof(one)) < 0) {
+        rfbLogPerror("rfbSockNotify: setsockopt");
+        close(sock);
+        return;
+      }
     }
 
     fprintf(stderr, "\n");
@@ -638,6 +669,61 @@ int ListenOnTCPPort(int port)
   if (getnameinfo(&addr.u.sa, addrlen, hostname, NI_MAXHOST, NULL, 0,
                   NI_NUMERICHOST) == 0)
     rfbLog("  Interface %s\n", hostname);
+
+  return sock;
+}
+
+
+int ListenOnUnixDomainSocket(const char *path, int mode)
+{
+  struct sockaddr_un addr;
+  mode_t saved_umask;
+  char hostname[NI_MAXHOST];
+  int sock;
+  int result;
+  int err;
+
+  if (strlen(path) >= sizeof(addr.sun_path)) {
+    rfbLog("socket path is too long");
+    errno = ENAMETOOLONG;
+    return -1;
+  }
+  memset(&addr, 0, sizeof(addr));
+  addr.sun_family = AF_UNIX;
+  strcpy(addr.sun_path, path);
+
+  /* Remove the socket if it exists and is stale */
+  if (access(path, F_OK) == 0) {
+    /* Check whether the socket is stale by trying to connect to it */
+    if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
+      return -1;
+
+    if (connect(sock, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+      /* If the socket is stale, delete it */
+      if (errno == ECONNREFUSED)
+        unlink(path);
+    }
+
+    close(sock);
+  }
+
+  if ((sock = socket(AF_UNIX, SOCK_STREAM, 0)) < 0)
+    return -1;
+
+  saved_umask = umask(0777 & ~mode);
+  result = bind(sock, (struct sockaddr *)&addr, sizeof(addr));
+  err = errno;
+  umask(saved_umask);
+  if (result < 0) {
+    close(sock);
+    errno = err;
+    return -1;
+  }
+
+  if (listen(sock, 5) < 0) {
+    close(sock);
+    return -1;
+  }
 
   return sock;
 }

--- a/unix/vncserver.in
+++ b/unix/vncserver.in
@@ -1,5 +1,6 @@
 #!/usr/bin/env perl
 #
+#  Copyright (C) 2021 Steffen Kieß
 #  Copyright (C) 2009-2018, 2020-2021 D. R. Commander.  All Rights Reserved.
 #  Copyright (C) 2010 University Corporation for Atmospheric Research.
 #                     All Rights Reserved.
@@ -62,6 +63,7 @@ $multiThread = 1;
 $numThreads = 0;
 $noVNC = "";
 $serverArgs = "";
+$rfbUnixPath = "";
 
 # Read configuration from the system-wide and user files if present.
 
@@ -203,7 +205,7 @@ foreach $_registrydir (@registrydirs) {
               "-3dwm", 0, "-vgl", 0, "-debug", 0, "-x509cert", 1,
               "-x509key", 1, "-autokill", 0, "-quiet", 0, "-wm", 1,
               "-sessionlist", 0, "-sessionstart", 0, "-novnc", 1,
-              "-noautokill", 0, "-rfbport", 1);
+              "-noautokill", 0, "-rfbport", 1, "-rfbunixpath", 1);
 
 &Usage() if ($opt{'-help'} || $opt{'-h'} || $opt{'--help'});
 
@@ -382,6 +384,10 @@ if ($opt{'-rfbport'}) {
   $vncPort = $opt{'-rfbport'};
 }
 
+if ($opt{'-rfbunixpath'}) {
+  $rfbUnixPath = $opt{'-rfbunixpath'};
+}
+
 if ($opt{'-log'}) {
   $desktopLog = $opt{'-log'};
 } else {
@@ -449,6 +455,7 @@ $cmd .= " -dridir $dridir" if ($dridir);
 $cmd .= " -registrydir $registrydir" if ($registrydir);
 $cmd .= " -nomt" if (!$multiThread);
 $cmd .= " -nthreads $numThreads" if ($numThreads);
+$cmd .= " -rfbunixpath " . &quotedString($rfbUnixPath) if ($rfbUnixPath);
 $cmd .= " $serverArgs" if ($serverArgs);
 
 foreach $arg (@ARGV) {
@@ -463,10 +470,26 @@ if (!$opt{'-debug'}) {
 $pidFile = "$vncUserDir/$host:$displayNumber.pid";
 system("$cmd & echo \$! >$pidFile");
 
+# Record the RFB unix socket path
+
+$sockPathFile = "$vncUserDir/$host:$displayNumber.sockpath";
+if ($rfbUnixPath) {
+  open(SOCK, '>', $sockPathFile);
+  print SOCK "$rfbUnixPath\n"
+} else {
+  unlink $sockPathFile;
+}
+
 # Give Xvnc a chance to start up
 
 sleep(1);
 unless (kill 0, `cat $pidFile`) {
+  # When Xvnc exits on startup the RFB socket might belong to another process.
+  # Remove the .sockpath file to prevent -kill from cleaning it up later.
+  if ($rfbUnixPath) {
+    unlink $sockPathFile;
+  }
+
   warn "Could not start Xvnc.\n\n";
   open(LOG, "<$desktopLog");
   while (<LOG>) { print; }
@@ -475,7 +498,11 @@ unless (kill 0, `cat $pidFile`) {
 }
 
 if (!$opt{'-sessionstart'}) {
-  warn "\nDesktop '$desktopName' started on display $host:$displayNumber\n\n";
+  warn "\nDesktop '$desktopName' started on display $host:$displayNumber\n";
+  if ($rfbUnixPath) {
+    warn "Listening on unix socket $rfbUnixPath\n";
+  }
+  warn "\n";
 }
 
 if ($generateOTP == 1) {
@@ -894,6 +921,7 @@ sub Kill
 
   if ($opt{'-kill'} =~ /^:\d+$/) {
     $pidFile = "$vncUserDir/$host$opt{'-kill'}.pid";
+    $sockPathFile = "$vncUserDir/$host$opt{'-kill'}.sockpath";
     $noVNCPIDFile = "$vncUserDir/$host$opt{'-kill'}-noVNC.pid";
   } else {
     if ($opt{'-kill'} !~ /^$host:/) {
@@ -901,6 +929,7 @@ sub Kill
           "Use -kill :<number> instead\n\n";
     }
     $pidFile = "$vncUserDir/$opt{'-kill'}.pid";
+    $sockPathFile = "$vncUserDir/$opt{'-kill'}.sockpath";
     $noVNCPIDFile = "$vncUserDir/$opt{'-kill'}-noVNC.pid";
   }
 
@@ -948,6 +977,14 @@ sub Kill
     warn "Xvnc process ID $pid already killed\n";
     $opt{'-kill'} =~ s/://;
 
+    if (-r $sockPathFile) {
+      chop($rfbUnixPath = `cat $sockPathFile`);
+      if (-e $rfbUnixPath) {
+        print "Xvnc did not appear to shut down cleanly.";
+        print " Removing $rfbUnixPath\n";
+        unlink $rfbUnixPath;
+      }
+    }
     if (-e "/tmp/.X11-unix/X$opt{'-kill'}") {
       print "Xvnc did not appear to shut down cleanly.";
       print " Removing /tmp/.X11-unix/X$opt{'-kill'}\n";
@@ -960,6 +997,7 @@ sub Kill
     }
   }
 
+  unlink $sockPathFile;
   unlink $pidFile;
   exit;
 }


### PR DESCRIPTION
Add the '-rfbunixpath' and '-rfbunixmode' options which will enable
listening on unix domain sockets.

The options are similar to the same options in TigerVNC, however
specifying '-rfbunixpath' will always disable listening on TCP and
'-rfbunixmode' is always parsed as an octal number.