### PR TITLE
Xvnc: Missing include in Mesa 20.3.5

### DIFF
--- a/unix/Xvnc/extras/Mesa/src/util/debug.h
+++ b/unix/Xvnc/extras/Mesa/src/util/debug.h
@@ -26,6 +26,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <stdlib.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
debug.c makes use of getenv() however u_string.h is not shipped and
commented out.  Reintroducing back as manual edit.

Fixes:

```
unix/Xvnc/extras/Mesa/src/util/debug.c:82:22: error: implicit declaration of function ‘getenv’ [-Wimplicit-function-declaration]
```

Further mesa import likely to resolve vs. manual edit
