### PR TITLE
Viewer: Fix accepting clipboard data from QEMU's VNC server

### DIFF
--- a/java/com/turbovnc/rdr/ZlibInStream.java
+++ b/java/com/turbovnc/rdr/ZlibInStream.java
@@ -102,6 +102,9 @@ public class ZlibInStream extends InStream {
   // stream.
 
   private boolean decompress(boolean wait) {
+    if (zs.inflateFinished())
+      throw new ErrorException("ZlibInStream: end of zlib stream");
+
     zs.next_out = b;
     zs.next_out_index = end;
     zs.avail_out = start + bufSize - end;
@@ -115,7 +118,8 @@ public class ZlibInStream extends InStream {
       zs.avail_in = bytesIn;
 
     int rc = zs.inflate(JZlib.Z_SYNC_FLUSH);
-    if (rc != JZlib.Z_OK) {
+
+    if (rc != JZlib.Z_OK && rc != JZlib.Z_STREAM_END) {
       throw new ErrorException("ZlibInStream: inflate failed");
     }
 


### PR DESCRIPTION
The `ServerCutText` message sent by the QEMU's VNC server contains a complete zlib stream with a final block at the end. Thus, when `inflate()` is called to decompress the zlib stream, `inflate()` will return `JZlib.Z_STREAM_END` when the end of stream is reached. In this case, it is not an error, and we should not throw an exception.

This fixes the issue #428.
