### PR TITLE
Correctly support HiDPI on macOS

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,1 @@
+use flake

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/build
+/.direnv
+/.zed

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,10 +1,29 @@
 Building TurboVNC
 =================
 
+## With nix
+You could use the provided nix flake as your build environment.
 
-Build Requirements
+1. Install the nix package manager
+```sh
+curl -fsSL https://install.determinate.systems/nix | sh -s -- install --determinate
+```
+
+2. Go into the provided environment
+```sh
+nix develop
+```
+
+3. Build this project
+```sh
+mkdir build && cd build
+cmake ..
+make -j
+```
+
+
+Without nix
 ------------------
-
 
 ### All Systems
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,58 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "id": "flake-utils",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1748281391,
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "bdc995d3e97cec29eacc8fbe87e66edfea26b861",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Unlicense
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    # systems.url = "github:nix-systems/default";
+  };
+
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+    }:
+    flake-utils.lib.eachSystem nixpkgs.lib.systems.flakeExposed (
+      system:
+      let
+        pkgs = import nixpkgs { inherit system; };
+      in
+      {
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            jdk24
+            cmake
+            libjpeg
+          ];
+        };
+      }
+    );
+}

--- a/java/com/turbovnc/vncviewer/CConn.java
+++ b/java/com/turbovnc/vncviewer/CConn.java
@@ -666,8 +666,12 @@ public final class CConn extends CConnection implements UserPasswdGetter,
           screenRect.x -= vpRect.x;
           screenRect.y -= vpRect.y;
 
-          Screen screen = new Screen(0, screenRect.x, screenRect.y,
-                                     screenRect.width, screenRect.height, 0);
+          double scale = viewport.getUiScale();
+          Screen screen = new Screen(
+              0, screenRect.x, screenRect.y,
+              (int)(screenRect.width*scale),
+              (int)(screenRect.height*scale), 0
+          );
 
           // We map client screens to server screens in the server's preferred
           // order (which, in the case of the TurboVNC Server, is always the

--- a/java/com/turbovnc/vncviewer/DesktopWindow.java
+++ b/java/com/turbovnc/vncviewer/DesktopWindow.java
@@ -416,21 +416,26 @@ class DesktopWindow extends JPanel implements Runnable, MouseListener,
   public void setScaledSize() {
     if (cc.params.scale.get() != ScaleParameter.AUTO &&
         cc.params.scale.get() != ScaleParameter.FIXEDRATIO) {
+      double uiScale = cc.viewport.getUiScale();
       scaledWidth = (int)Math.floor((float)cc.cp.width *
-                                    (float)cc.params.scale.get() / 100.0);
+                                    (float)cc.params.scale.get() / uiScale / 100.0);
       scaledHeight = (int)Math.floor((float)cc.cp.height *
-                                     (float)cc.params.scale.get() / 100.0);
+                                     (float)cc.params.scale.get() / uiScale / 100.0);
+      vlog.debug("Setting desktop scaled size: multiplying scale, scale="+cc.params.scale.get());
     } else {
       if (cc.viewport == null) {
         scaledWidth = cc.cp.width;
         scaledHeight = cc.cp.height;
+        vlog.debug("Setting desktop scaled size: viewport is null");
       } else {
         Dimension availableSize = cc.viewport.getAvailableSize();
         if (availableSize.width == 0 || availableSize.height == 0) {
+          vlog.debug("Setting desktop scaled size: availbe size is 0");
           availableSize.width = cc.cp.width;
           availableSize.height = cc.cp.height;
         }
         if (cc.params.scale.get() == ScaleParameter.FIXEDRATIO) {
+          vlog.debug("Setting desktop scaled size: fixed ratio");
           float widthRatio = (float)availableSize.width / (float)cc.cp.width;
           float heightRatio =
             (float)availableSize.height / (float)cc.cp.height;
@@ -438,6 +443,7 @@ class DesktopWindow extends JPanel implements Runnable, MouseListener,
           scaledWidth = (int)Math.floor(cc.cp.width * ratio);
           scaledHeight = (int)Math.floor(cc.cp.height * ratio);
         } else {
+          vlog.debug("Setting desktop scaled size to availableSize");
           scaledWidth = availableSize.width;
           scaledHeight = availableSize.height;
         }


### PR DESCRIPTION
# Comparison
codec is lossless tight

Before:
<img width="1269" alt="图片" src="https://github.com/user-attachments/assets/5c9d8863-4c9b-4422-81ea-bf6113e3d066" />

After:
<img width="1169" alt="图片" src="https://github.com/user-attachments/assets/96e9ac80-1285-44c5-b2ab-b6550e78c443" />


# Supporting HiDPI
TurboVNC viewer currently advertises HiDPI support in `Info.plist`, but only makes toolbar text crisp; the remote desktop is still blurry. We would need to send the HiDPI resolution to the remote server, rather than logical (unscaled) resolution. 

My code is tested on macOS.

## macOS's HiDPI implementation
Some notes on HiDPI screens on macOS: 

there are 3 different resolutions on macOS (named by me):
- logical: The UI size should be rendered as if it were on a screen with logical size
- physical: The actual physical pixels the app is occupying
- rendered: The size that macOS tells this app to render at.

For example, if you have a 150x150 display and tells macOS that you want it to look like a 100x100 screen, then you effectively asked for 1.5x scale. However, macOS applications doesn't support fraction scaling, only integer ones. Therefore, macOS would tell the app to render at 200x200, with a 2x scale. Then, macOS downsamples this to 150x150. For the application, the logical resolution is 100x100 and rendered resolution is 200x200.

For a VNC, it is best to resize remote to physical size and display it pixel-to-pixel. But that could be troublesome; I don't know how to get the physical size in java, for example. So I chose the 2nd best: ask for a rendered resolution, and still let macOS to downsample it. The good thing about this is we won't require the remote server to do fraction scaling (which often also involves 2x scaling + downsample), and we also get very sharp text. 