### PR TITLE
Fix ws binary/base64 subprotocol priority

### DIFF
--- a/unix/Xvnc/programs/Xserver/hw/vnc/websockets.c
+++ b/unix/Xvnc/programs/Xserver/hw/vnc/websockets.c
@@ -165,6 +165,8 @@ static Bool webSocketsHandshake(rfbClientPtr cl, char *scheme)
   char *sec_ws_origin = NULL;
   char *sec_ws_key = NULL;
   char sec_ws_version = 0;
+  const char *proto_binary;
+  const char *proto_base64;
   ws_ctx_t *wsctx = NULL;
   char accept[B64LEN(SHA1_HASH_SIZE) + 1];
 
@@ -268,13 +270,15 @@ static Bool webSocketsHandshake(rfbClientPtr cl, char *scheme)
     return FALSE;
   }
 
-  if ((protocol) && (strstr(protocol, "base64"))) {
+  proto_binary = protocol ? strstr(protocol, "binary") : NULL;
+  proto_base64 = protocol ? strstr(protocol, "base64") : NULL;
+  if (proto_base64 && (!proto_binary || proto_base64 < proto_binary)) {
     RFBLOGID("  - webSocketsHandshake: using base64 encoding\n");
     base64 = TRUE;
     protocol = "base64";
   } else {
     RFBLOGID("  - webSocketsHandshake: using binary/raw encoding\n");
-    if ((protocol) && (strstr(protocol, "binary")))
+    if (proto_binary)
       protocol = "binary";
     else
       protocol = "";


### PR DESCRIPTION
The problem is when the client advertises `"protocol": ["binary", "base64"]`, the server picks `base64`. The server should prefer the first one.

It's an issue when the client had this configuration as a fix to the `400 Client must support 'binary' or 'base64' protocol` error with noVNC and old websockify + VNC: https://github.com/novnc/noVNC/issues/1276#issuecomment-564677833 . Today it seems that noVNC doesn't do `base64` any more. Although it's now incorrect for the client to advertise both protocols, it's not intuitive that `"protocol": ["binary", "base64"]` doesn't work while `"protocol": ["binary"]` does.

Relevant PR/issue:

https://github.com/LibVNC/libvncserver/pull/342

https://github.com/novnc/noVNC/issues/1310

https://github.com/LibVNC/libvncserver/pull/595