### PR TITLE
Xvnc: Assign XI device type Atoms to core devices

### DIFF
--- a/unix/Xvnc/programs/Xserver/hw/vnc/init.c
+++ b/unix/Xvnc/programs/Xserver/hw/vnc/init.c
@@ -1208,6 +1208,15 @@ void InitInput(int argc, char *argv[])
   if (!EnableDevice(p, TRUE) || !EnableDevice(k, TRUE))
     FatalError("Could not enable TurboVNC input devices");
 
+  /* Assign the standard X Input device type Atoms to the core devices, as
+     Xvfb and the X.org input drivers do.  Chromium only recognizes a pointing
+     device if its type Atom is XI_MOUSE, so without this, the CSS interaction
+     media features report "hover: none" and "pointer: none", and web pages
+     that gate hover styles behind @media (hover: hover) (e.g. any site built
+     with Tailwind CSS v4) never show their hover-triggered UI. */
+  p->xinput_type = MakeAtom(XI_MOUSE, sizeof(XI_MOUSE) - 1, TRUE);
+  k->xinput_type = MakeAtom(XI_KEYBOARD, sizeof(XI_KEYBOARD) - 1, TRUE);
+
   mieqInit();
   mieqSetHandler(ET_KeyPress, vncXkbProcessDeviceEvent);
   mieqSetHandler(ET_KeyRelease, vncXkbProcessDeviceEvent);


### PR DESCRIPTION
### Problem

Chromium running inside a TurboVNC session reports that the machine has no pointing device: `matchMedia("(hover: hover)").matches`, `("(any-hover: hover)")`, `("(pointer: fine)")`, and `("(any-pointer: fine)")` are all `false` (`(pointer: none)` is `true`).

The `:hover` pseudo-class and pointer events work normally, so the symptom is subtle: only style rules gated behind the CSS interaction media features are affected — they are discarded wholesale. This has become much more visible recently because Tailwind CSS v4 wraps every `hover:` utility in `@media (hover: hover)` by default, so on sites built with it (a rapidly growing set), hover-revealed UI such as menus, action buttons, and tooltips never appears in a browser running under Xvnc, while working fine on any physical desktop.

### Root cause

Chromium's pointing-device detection on X11 classifies the devices returned by `ListInputDevices` by their X Input device type Atom — a device counts as a mouse only if its type Atom is `"MOUSE"` (or `"xwayland-pointer"`), and devices whose name contains `XTEST` are ignored:

- [`ui/events/platform/x11/x11_hotplug_event_handler.cc`](https://source.chromium.org/chromium/chromium/src/+/main:ui/events/platform/x11/x11_hotplug_event_handler.cc) (type Atom matching, XTEST filtering)
- [`ui/base/pointer/pointer_device_linux.cc`](https://source.chromium.org/chromium/chromium/src/+/main:ui/base/pointer/pointer_device_linux.cc) (mouse presence → `POINTER_TYPE_FINE` / `HOVER_TYPE_HOVER`)

The core pointer/keyboard pair that `InitInput()` creates via `AllocDevicePair()` carries no type Atom, so Chromium finds no recognizable pointing device:

```
$ xinput list          # in a TurboVNC session; type Atom of every device is None
⎡ Virtual core pointer                    id=2  [master pointer  (3)]
⎜   ↳ Virtual core XTEST pointer          id=4  [slave  pointer  (2)]
⎜   ↳ TurboVNC pointer                    id=6  [slave  pointer  (2)]
...
```

Xvfb labels its equivalent virtual devices ([`hw/vfb/InitInput.c`](https://gitlab.freedesktop.org/xorg/xserver/-/blob/master/hw/vfb/InitInput.c)):

```c
xiclass = MakeAtom(XI_MOUSE, sizeof(XI_MOUSE) - 1, TRUE);
AssignTypeAndName(p, xiclass, "Xvfb mouse");
```

and accordingly Chromium under Xvfb reports `hover: hover` / `pointer: fine`. Xvnc itself already assigns type Atoms to extended input devices in `AddExtInputDevice()` (CURSOR/STYLUS/ERASER/TOUCH/PAD) — only the core pair is unlabeled.

### Fix

Assign `XI_MOUSE`/`XI_KEYBOARD` to the core device pair in `InitInput()`, mirroring Xvfb and the X.org input drivers. Device names and event delivery are unchanged; the type Atom is otherwise vestigial (X Input 1.x device classification), so the change is not expected to affect any other consumer.

### Verification

Controlled comparison with Chrome 126 on Linux, same container:

| X server | pointer type Atom | `(hover: hover)` | `(pointer: fine)` |
|---|---|---|---|
| TurboVNC 3.1.3 Xvnc (stock) | none | false | false |
| Xvfb | `MOUSE` | true | true |
| TurboVNC 3.1.3 Xvnc + this change | `MOUSE` | true | true |

With the patched Xvnc, `@media (hover: hover)`-gated styles (including Tailwind v4 `hover:` utilities) apply normally on real-world sites; a test page exercising `:hover`, pointer events, and the interaction media queries behaves identically to a physical desktop. Also compile-tested against `main`.
